### PR TITLE
Fix problem where queue/exchange is not removed if emitAndWait gets an error

### DIFF
--- a/test/listening.test.ts
+++ b/test/listening.test.ts
@@ -3,8 +3,8 @@ import { describe, it } from 'mocha';
 import * as sinon from 'sinon';
 import * as adapter from '../src/adapter';
 import EventManager from '../src/index';
-import { IEventManagerOptions } from '../src/lib/interfaces';
 import { EventManagerError } from '../src/lib/EventManagerError';
+import { IEventManagerOptions } from '../src/lib/interfaces';
 describe('RabbitMQ Event Manager, Listening events ', () => {
   let sandbox: sinon.SinonSandbox;
   beforeEach(() => {


### PR DESCRIPTION
Hi, thanks for the great module!  I noticed that if an emitAndWait call gets an error (a timeout, for example), the response queue/exchange is not cleaned up.  This PR fixes that.